### PR TITLE
Add vanity cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ python setup.py install
 ## Quick start
 SYBA input is a CSV (comma-separated value) file consisting of the following columns: CMPND_ID,SMILES,OTHER_COLUMNS. OTHER_COLUMNS can contain any additional data and these columns are skipped. Output is a CSV file in the format ID,SMILES,SYBA_SCORE. SYBA reflects how confident the classifier is with its prediction (i.e., SYBA score can't be considered as a measure of the ease of synthesis). Negative SYBA values mean a hard-to-synthesize compound and positive mean an easy-to-synthesize one.
 
+SYBA is automatically installs a command line tool `syba`.
 SYBA classification is performed by the following command:
 
 ```bash
-python -m syba.syba [INPUT_FILE [OUTPUT_FILE]]
+$ syba [INPUT_FILE [OUTPUT_FILE]]
 ```
 ## Use in Python script
 ### Basic usage

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,9 @@ setup(name='syba',
       package_data={'syba': ['resources/syba.csv.gz', 'resources/syba4.csv.gz'],},
       zip_safe=False,
       include_package_data=True,
+      entry_points={
+          'console_scripts': [
+              'syba = syba.syba:main',
+          ],
+      },
      )

--- a/syba/syba.py
+++ b/syba/syba.py
@@ -236,7 +236,7 @@ def writeCountFile(filename, fragments_counts, compound_counts):
             out.write("{},{},{}\n".format(fragment_id, counts[0], counts[1]))
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     import sys
 
@@ -260,3 +260,7 @@ if __name__ == "__main__":
         out.write("ID,SMILES,SYBA\n")
         for mol, *spls in supp:
             out.write(f"{spls[0]},{Chem.MolToSmiles(mol)},{syba.predict(mol=mol)}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2 

This PR does three things:

1. It encapsulates the script functionality in `syba/syba.py` found in the `if __name__ == '__main__': ...` block in its own function, `def main(): ...`. The `if __name__ == '__main__':` block now simply calls `main()`. There is no change in functionality.
2. Adds an entrypoint in `setup.py` to automatically generate a CLI tool `syba` that points to this `main()` function
3. Update the README to reflect this

Note: previous usage of `python -m syba.syba` will continue to work! The vanity CLI is just icing on the cake :)