### PR TITLE
Automatically load default data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ from rdkit import Chem
 from syba.syba import SybaClassifier
 
 syba = SybaClassifier()
-syba.fitDefaultScore()
 smi = "O=C(C)Oc1ccccc1C(=O)O"
 syba.predict(smi)
 # syba works also with RDKit RDMol objects

--- a/docs/notebooks/draw_fragment_score.ipynb
+++ b/docs/notebooks/draw_fragment_score.ipynb
@@ -49,8 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = syba.SybaClassifier()\n",
-    "s.fitDefaultScore()"
+    "s = syba.SybaClassifier()"
    ]
   },
   {

--- a/docs/notebooks/prepare_results.ipynb
+++ b/docs/notebooks/prepare_results.ipynb
@@ -111,7 +111,6 @@
    ],
    "source": [
     "syba = SybaClassifier()\n",
-    "syba.fitDefaultScore()\n",
     "syba.predict(smi)"
    ]
   },

--- a/syba/syba.py
+++ b/syba/syba.py
@@ -30,7 +30,7 @@ class SybaClassifier:
     """
     SYBA clasifier
     """
-    def __init__(self, neighbourhood=4):
+    def __init__(self, neighbourhood=4, count_file=None):
         self.fragments = {}
         self.ALL_OFF_FRAGS_SCORE = None
         self.pNS = None
@@ -43,6 +43,8 @@ class SybaClassifier:
                  4: (-2.939230216688627, 0.1883123534101861),
                  5: (-4.536353950205819, 0.2060140915608036)
                 }
+        if count_file is None:
+            self.fitDefaultScore()
 
 
     def fitDefaultScore(self):

--- a/syba/syba.py
+++ b/syba/syba.py
@@ -30,7 +30,7 @@ class SybaClassifier:
     """
     SYBA clasifier
     """
-    def __init__(self, neighbourhood=4, count_file=None):
+    def __init__(self, neighbourhood=4, load_default=True):
         self.fragments = {}
         self.ALL_OFF_FRAGS_SCORE = None
         self.pNS = None
@@ -43,7 +43,7 @@ class SybaClassifier:
                  4: (-2.939230216688627, 0.1883123534101861),
                  5: (-4.536353950205819, 0.2060140915608036)
                 }
-        if count_file is None:
+        if load_default:
             self.fitDefaultScore()
 
 

--- a/syba/syba.py
+++ b/syba/syba.py
@@ -253,7 +253,6 @@ if __name__ == "__main__":
     
     this_dir, this_filename = os.path.split(__file__)
     syba = SybaClassifier()
-    syba.fitDefaultScore()
 
     with args.output_file as out, args.input_file as inp:
         if header:


### PR DESCRIPTION
Closes #4 

This PR introduces a keyword `load_default` to `SybaClassifier.__init__()` that defaults to true. When it's true, it will automatically call `self.fitDefaultScore()`. This means that the vanilla usage

```python
from syba.syba import SybaClassifier
syba_classifier = SybaClassifier()
syba_classifier.fitDefaultScore()
...
```

can be reduced to one line

```python
from syba.syba import SybaClassifier
syba_classifier = SybaClassifier()
...
```

This PR also updates all usages (e.g., in README, jupyter notebooks, python code) to reflect this.